### PR TITLE
main.css: set `height: auto` for images in <main>

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -25,7 +25,7 @@ main {padding: 30px;max-width: 700px;margin: 0 auto;}
 main a {color: white;}
 main p img {padding: 10px;}
 main pre {border: 1px solid white; padding: 15px; overflow: scroll;}
-main img {max-width: 100%;}
+main img {max-width: 100%; height: auto;}
 
 main .button { background-color: #000;border: 2px solid white;color: white;padding: 5px 28px;text-align: center;text-decoration: none;display: inline-block;font-size: 18px;border-radius: 200px;font-weight: bold; margin-top: 10px; margin-right: 15px; margin-bottom: 10px;}
 main .button:hover { background-color: #333 !important; color: white; cursor:pointer; }


### PR DESCRIPTION
This prevents them from being distorted on narrow viewports if `width` and `height` are specified.

See [defensive boating][0] as an example.

[0]: https://kokorobot.ca/site/defensive_boating.html