### PR TITLE
Fix broken favicon

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -177,8 +177,8 @@ build(FILE *f, Lexicon *l, char *name, char *srcpath)
 		"<link rel='alternate' type='application/rss+xml' title='RSS Feed' "
 		"href='../links/rss.xml' />"
 		"<link rel='stylesheet' type='text/css' href='../links/main.css'>"
-		"<link rel='shortcut icon' type='image/png' "
-		"href='../media/services/shortcut.png'>"
+		"<link rel='shortcut icon' type='image/x-icon' "
+		"href='../media/services/favicon.ico'>"
 		"<title>" NAME " &mdash; %s</title>",
 		name);
 	fputs("</head>", f);


### PR DESCRIPTION
This PR changes the `href` of the favicon to a file that actually exists (`media/services/favicon.ico`) as opposed to one that doesn't (`media/services/shortcut.png`). This restores the favicon in browsers.